### PR TITLE
Add fallback currency API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ A lightweight Chrome/Edge extension that calculates the estimated cost of your B
 ## Features
 
 - **Cost Calculation:** Automatically reads the displayed query size and applies a standard price per TB rate (default: \$6.25/TB).
-- **No Server Calls:** All cost calculations are performed locally; no data is transmitted to any external server.
+- **No Server Calls:** All cost calculations are performed locally; no query information leaves your browser. Exchange rates are retrieved only if you click **Update Rate**.
 - **Easy to Use:** Once installed, the Extension appends a simple cost estimate next to BigQuery’s own “Estimated to process…” text.
+- **Multilingual Options Page:** Interface text adapts to English, Portuguese or Spanish based on your browser language.
+- **Automatic Currency Updates:** Fetch conversion rates from the free [currency-api](https://github.com/fawazahmed0/exchange-api) with a single click—no tokens required.
+- **Custom Currency Support:** Still set your own currency code, symbol and rate if you prefer.
 
 ## Installation
 
@@ -14,7 +17,9 @@ A lightweight Chrome/Edge extension that calculates the estimated cost of your B
 2. **Go to** `chrome://extensions` (Chrome) or `edge://extensions` (Edge).
 3. **Enable** **Developer Mode** (usually found in the top-right corner).
 4. **Load Unpacked** and select the folder containing `manifest.json`.
-5. Reload the BigQuery Console. The cost estimate will appear automatically whenever the query size is displayed.
+5. When prompted, allow access to jsDelivr and currency-api.pages.dev so the extension can fetch rates.
+6. Reload the BigQuery Console. The cost estimate will appear automatically whenever the query size is displayed.
+7. Open the extension options to configure your currency. Click **Update Rate** to pull the latest exchange rate.
 
 ## Contributing
 

--- a/content.js
+++ b/content.js
@@ -169,12 +169,13 @@ if (typeof browser === 'undefined') {
     /**
      * Fetch user preferences from storage, then start the observer.
      */
-    const defaultPrefs = {
-      showUSD: true,
-      customCurrencyEnabled: false,
-      customCurrencySymbol: "R$",
-      customCurrencyRate: 4.9
-    };
+      const defaultPrefs = {
+        showUSD: true,
+        customCurrencyEnabled: false,
+        customCurrencyCode: "BRL",
+        customCurrencySymbol: "R$",
+        customCurrencyRate: 4.9
+      };
   
     browser.storage.sync.get(defaultPrefs, (prefs) => {
       startObserver(prefs);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "BigQuery Cost Estimator",
-  "version": "1.0",
+  "version": "1.2",
   "description": "Displays the estimated cost of BigQuery queries in the console.",
   "background": {
     "service_worker": "background.js"
@@ -9,6 +9,10 @@
   "permissions": [
     "scripting",
     "storage"
+  ],
+  "host_permissions": [
+    "https://cdn.jsdelivr.net/*",
+    "https://*.currency-api.pages.dev/*"
   ],
   "options_ui": {
     "page": "options.html",

--- a/options.html
+++ b/options.html
@@ -5,32 +5,38 @@
     <title>BigQuery Cost Estimator Options</title>
   </head>
   <body>
-    <h1>BigQuery Cost Estimator Options</h1>
+    <h1 id="title">BigQuery Cost Estimator Options</h1>
 
     <div>
       <label>
         <input type="checkbox" id="enableUsd" />
-        Show USD (Base)
+        <span id="labelShowUsd">Show USD (Base)</span>
       </label>
     </div>
 
     <hr />
 
-    <h2>Custom Currency (BRL Example)</h2>
+    <h2 id="customCurrencyHeading">Custom Currency</h2>
     <label>
       <input type="checkbox" id="enableCustom" />
-      Enable Custom Currency
+      <span id="labelEnableCustom">Enable Custom Currency</span>
     </label>
     <br />
     <label>
-      Symbol:
+      <span id="labelCode">Currency Code:</span>
+      <input type="text" id="customCode" value="BRL" />
+    </label>
+    <br />
+    <label>
+      <span id="labelSymbol">Symbol:</span>
       <input type="text" id="customSymbol" value="R$" />
     </label>
     <br />
     <label>
-      Rate (relative to 1 USD):
+      <span id="labelRate">Rate (relative to 1 USD):</span>
       <input type="number" step="0.01" id="customRate" value="4.90" />
     </label>
+    <button id="updateRateBtn">Update Rate</button>
 
     <hr />
 

--- a/options.js
+++ b/options.js
@@ -2,55 +2,160 @@
 
 // If 'browser' is undefined, use 'chrome' instead (for Edge/Chrome compatibility).
 if (typeof browser === 'undefined') {
-    var browser = chrome;
+  var browser = chrome;
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const enableUsdCheckbox = document.getElementById("enableUsd");
+  const enableCustomCheckbox = document.getElementById("enableCustom");
+  const customCodeInput = document.getElementById("customCode");
+  const customSymbolInput = document.getElementById("customSymbol");
+  const customRateInput = document.getElementById("customRate");
+  const updateRateBtn = document.getElementById("updateRateBtn");
+  const saveBtn = document.getElementById("saveBtn");
+  const statusMessage = document.getElementById("statusMessage");
+
+  const translations = {
+    en: {
+      title: "BigQuery Cost Estimator Options",
+      showUSD: "Show USD (Base)",
+      customHeading: "Custom Currency",
+      enableCustom: "Enable Custom Currency",
+      code: "Currency Code:",
+      symbol: "Symbol:",
+      rate: "Rate (relative to 1 USD):",
+      updateRate: "Update Rate",
+      save: "Save",
+      saved: "Settings saved!",
+      updated: "Rate updated!",
+      updateFailed: "Failed to fetch rate"
+    },
+    pt: {
+      title: "Opções do Estimador de Custos do BigQuery",
+      showUSD: "Mostrar USD (Base)",
+      customHeading: "Moeda Personalizada",
+      enableCustom: "Ativar Moeda Personalizada",
+      code: "Código da Moeda:",
+      symbol: "Símbolo:",
+      rate: "Taxa (relativa a 1 USD):",
+      updateRate: "Atualizar Taxa",
+      save: "Salvar",
+      saved: "Configurações salvas!",
+      updated: "Taxa atualizada!",
+      updateFailed: "Falha ao obter taxa"
+    },
+    es: {
+      title: "Opciones del Estimador de Costos de BigQuery",
+      showUSD: "Mostrar USD (Base)",
+      customHeading: "Moneda Personalizada",
+      enableCustom: "Habilitar Moneda Personalizada",
+      code: "Código de Moneda:",
+      symbol: "Símbolo:",
+      rate: "Tasa (relativa a 1 USD):",
+      updateRate: "Actualizar Tasa",
+      save: "Guardar",
+      saved: "¡Configuraciones guardadas!",
+      updated: "¡Tasa actualizada!",
+      updateFailed: "Error al obtener la tasa"
+    }
+  };
+
+  let messages = translations.en;
+  function applyTranslations() {
+    const lang = (navigator.language || "en").slice(0, 2);
+    messages = translations[lang] || translations.en;
+    document.getElementById("title").textContent = messages.title;
+    document.getElementById("labelShowUsd").textContent = messages.showUSD;
+    document.getElementById("customCurrencyHeading").textContent = messages.customHeading;
+    document.getElementById("labelEnableCustom").textContent = messages.enableCustom;
+    document.getElementById("labelCode").textContent = messages.code;
+    document.getElementById("labelSymbol").textContent = messages.symbol;
+    document.getElementById("labelRate").textContent = messages.rate;
+    updateRateBtn.textContent = messages.updateRate;
+    saveBtn.textContent = messages.save;
   }
-  
-  document.addEventListener("DOMContentLoaded", () => {
-    const enableUsdCheckbox = document.getElementById("enableUsd");
-    const enableCustomCheckbox = document.getElementById("enableCustom");
-    const customSymbolInput = document.getElementById("customSymbol");
-    const customRateInput = document.getElementById("customRate");
-    const saveBtn = document.getElementById("saveBtn");
-    const statusMessage = document.getElementById("statusMessage");
-  
-    // Default settings if not stored yet
-    const defaultPrefs = {
-      showUSD: true,
-      customCurrencyEnabled: false,
-      customCurrencySymbol: "R$",
-      customCurrencyRate: 5.85
-    };
-  
-    // Load current settings from storage (returns a Promise in the polyfill)
-    browser.storage.sync.get(defaultPrefs, (items) => {
-      enableUsdCheckbox.checked = items.showUSD;
-      enableCustomCheckbox.checked = items.customCurrencyEnabled;
-      customSymbolInput.value = items.customCurrencySymbol;
-      customRateInput.value = items.customCurrencyRate;
-    });
-  
-    // Save new settings
-    saveBtn.addEventListener("click", () => {
-      const showUSD = enableUsdCheckbox.checked;
-      const customCurrencyEnabled = enableCustomCheckbox.checked;
-      const customCurrencySymbol = customSymbolInput.value;
-      const customCurrencyRate = parseFloat(customRateInput.value) || 0;
-  
-      browser.storage.sync.set(
-        {
-          showUSD,
-          customCurrencyEnabled,
-          customCurrencySymbol,
-          customCurrencyRate
-        },
-        () => {
-          // Display a status message
-          statusMessage.textContent = "Settings saved!";
-          setTimeout(() => {
-            statusMessage.textContent = "";
-          }, 3000);
-        }
-      );
-    });
+
+  applyTranslations();
+
+  // Default settings if not stored yet
+  const defaultPrefs = {
+    showUSD: true,
+    customCurrencyEnabled: false,
+    customCurrencyCode: "BRL",
+    customCurrencySymbol: "R$",
+    customCurrencyRate: 5.85
+  };
+
+  // Load current settings from storage
+  browser.storage.sync.get(defaultPrefs, (items) => {
+    enableUsdCheckbox.checked = items.showUSD;
+    enableCustomCheckbox.checked = items.customCurrencyEnabled;
+    customCodeInput.value = items.customCurrencyCode;
+    customSymbolInput.value = items.customCurrencySymbol;
+    customRateInput.value = items.customCurrencyRate;
   });
-  
+
+  async function getRate(code) {
+    const c = code.toLowerCase();
+    const primary = `https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/usd/${c}.json`;
+    const fallback = `https://latest.currency-api.pages.dev/v1/currencies/usd/${c}.json`;
+    try {
+      const r = await fetch(primary);
+      if (!r.ok) throw new Error("primary failed");
+      const d = await r.json();
+      if (d && d.usd && d.usd[c]) return d.usd[c];
+      throw new Error("missing rate");
+    } catch (err) {
+      try {
+        const r2 = await fetch(fallback);
+        if (!r2.ok) throw new Error("fallback failed");
+        const d2 = await r2.json();
+        if (d2 && d2.usd && d2.usd[c]) return d2.usd[c];
+      } catch (e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  // Fetch latest rate for the selected currency
+  updateRateBtn.addEventListener("click", async () => {
+    const code = customCodeInput.value.trim().toUpperCase();
+    if (!code) return;
+    const rate = await getRate(code);
+    if (rate) {
+      customRateInput.value = rate.toFixed(2);
+      statusMessage.textContent = messages.updated;
+    } else {
+      statusMessage.textContent = messages.updateFailed;
+    }
+    setTimeout(() => {
+      statusMessage.textContent = "";
+    }, 3000);
+  });
+
+  // Save new settings
+  saveBtn.addEventListener("click", () => {
+    const showUSD = enableUsdCheckbox.checked;
+    const customCurrencyEnabled = enableCustomCheckbox.checked;
+    const customCurrencyCode = customCodeInput.value.trim().toUpperCase();
+    const customCurrencySymbol = customSymbolInput.value;
+    const customCurrencyRate = parseFloat(customRateInput.value) || 0;
+
+    browser.storage.sync.set(
+      {
+        showUSD,
+        customCurrencyEnabled,
+        customCurrencyCode,
+        customCurrencySymbol,
+        customCurrencyRate
+      },
+      () => {
+        statusMessage.textContent = messages.saved;
+        setTimeout(() => {
+          statusMessage.textContent = "";
+        }, 3000);
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- switch to the free currency-api service with jsDelivr/Cloudflare fallback
- update README to mention the new API and permissions
- bump extension version to 1.2 and adjust host permissions

## Testing
- `node --check options.js`
- `node --check content.js`
